### PR TITLE
chore: Image Modal Component Click Outside

### DIFF
--- a/src/components/ImageModal.tsx
+++ b/src/components/ImageModal.tsx
@@ -3,7 +3,7 @@ import React from "react";
 const ImageModal = ({ image, onClose }: { image: string; onClose: () => void }) => {
     return (
         // bg-opacity-75
-        <div className="fixed inset-0 bg-black/60 backdrop-blur-xl flex items-center justify-center z-50">
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-xl flex items-center justify-center z-50" onClick={onClose}>
             <div className="relative">
                 {/* Close Button */}
                 <button


### PR DESCRIPTION
This pull request includes a small change to the `src/components/ImageModal.tsx` file. The change adds an `onClick` event handler to the modal container to close the modal when the background is clicked.

* [`src/components/ImageModal.tsx`](diffhunk://#diff-deefa87af45af4abc9b47887c187cd96b0bb64db104debd2e081aa5ad7d1d50aL6-R6): Added `onClick={onClose}` to the modal container to allow closing the modal by clicking the background.